### PR TITLE
feat(Options): use C_AddOns.GetAddOnMetadata

### DIFF
--- a/FastWhisper/Options/LibAddonManager.lua
+++ b/FastWhisper/Options/LibAddonManager.lua
@@ -1,7 +1,7 @@
 local type = type
 local CreateFrame = CreateFrame
 local tinsert = tinsert
-local GetAddOnMetadata = GetAddOnMetadata
+local GetAddOnMetadata = C_AddOns.GetAddOnMetadata or GetAddOnMetadata
 local tonumber = tonumber
 local tostring = tostring
 local select = select


### PR DESCRIPTION
GetAddOnMetadata has been removed in patch 11.0.2